### PR TITLE
Fixed exception when creating a device.

### DIFF
--- a/device/wemo/wemo-insight-switch.groovy
+++ b/device/wemo/wemo-insight-switch.groovy
@@ -64,7 +64,9 @@ private debug(data){
 // parse events into attributes
 def parse(String description) {
     def map = stringToMap(description)
-    def headerString = new String(map.headers.decodeBase64())
+    def headerString = ""
+    if (map.headers)
+       headerString = new String(map.headers.decodeBase64())
     def result = []
     
     // update subscriptionId


### PR DESCRIPTION
This commit fixes the issue reported at
https://community.smartthings.com/t/wemo-insight-switches/1704/32

I only got my hub a few hours ago so this is my first exposure to Groovy and I just blindly fixed the exception - map.headers.decodeBase64() returns null if headers is empty. If there's a better solution please let me know. After this fix I was able to add WeMo Insight switches and operate them successfully.
